### PR TITLE
fix: no Lenis smooth scrolling on member-info popout

### DIFF
--- a/src/components/page/MemberInfo.astro
+++ b/src/components/page/MemberInfo.astro
@@ -3,7 +3,7 @@ import { X } from "@lucide/astro";
 const { id = "member-info-modal" } = Astro.props;
 ---
 
-<div id={id} class="member-info" data-lenis-prevent>
+<div id={id} class="member-info">
 	<div class="header">
 		<button class="close-btn" aria-label="關閉">
 			<X size={24} strokeWidth={3} />


### PR DESCRIPTION
In `/team` page, moving cursor onto the `member-info-modal` won't have smooth scrolling:

https://github.com/user-attachments/assets/b9f8c383-d199-4141-a1aa-233f2245c701

But since https://github.com/sitcon-tw/2026/commit/1f401561ba320ed20f43bff6ecc4ae50a50fc39a exists, I'm not quite sure why `data-lenis-prevent` is explicitly added. 
