### PR TITLE
fix(Discuss): prevent infinite loop in chat message cleanup

### DIFF
--- a/src/components/index/Discuss.astro
+++ b/src/components/index/Discuss.astro
@@ -324,10 +324,11 @@ const messages = t.messages;
 				});
 			}
 
-			// 清理舊訊息
-			while (chatStream.children.length > MAX_BUBBLES) {
+			// 清理舊訊息 - 每次只處理一個，避免無限循環
+			if (chatStream.children.length > MAX_BUBBLES) {
 				const oldest = chatStream.firstElementChild as HTMLElement;
-				if (oldest) {
+				if (oldest && !oldest.dataset.removing) {
+					oldest.dataset.removing = "true"; // 標記避免重複動畫
 					gsap.to(oldest, {
 						opacity: 0,
 						duration: 0.3,


### PR DESCRIPTION
related to #120 

## Fix memory leak in Discuss chat animation

### Problem
The chat animation caused a memory leak that crashed the browser tab after a few seconds. JS heap would spike to tens of times its normal size.

### Root Cause
The `while` loop for cleaning up old messages combined with async `gsap.to()` created an infinite loop:

```js
// Before (problematic)
while (chatStream.children.length > MAX_BUBBLES) {
  const oldest = chatStream.firstElementChild;
  gsap.to(oldest, {
    onComplete: () => oldest.remove() // Async - runs 0.3s later
  });
}
```

- `gsap.to()` is async - `oldest.remove()` executes after 0.3s
- `while` loop is sync - checks `children.length` immediately
- Element not removed yet → `children.length` unchanged → loop continues
- Result: infinite GSAP tweens created on the same element → memory explosion

### Fix
1. Changed `while` → `if`: Only remove one message per `addMessage()` call (since we only add one)
2. Added `dataset.removing` flag: Prevents duplicate animations on the same element