### PR TITLE
fix: github action running on forked repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   push:
     runs-on: ubuntu-latest
+    if: github.repository == 'sitcon-tw/2026'
     steps:
       - uses: actions/checkout@v4
       - name: Set timezone to Asia/Taipei


### PR DESCRIPTION
If contributors directly apply modification onto their forked repository's `main` branch, the GitHub Action will be triggered on forked repository and fail.

This PR fixes it by validating current running repository.