### PR TITLE
fix: use load event + rAF for text reveal to ensure fonts are ready

### DIFF
--- a/src/utils/text-reveal.ts
+++ b/src/utils/text-reveal.ts
@@ -213,13 +213,17 @@ export const cleanupTextReveal = (): void => {
 // 自動初始化
 if (typeof window !== "undefined") {
 	// 頁面首次載入
-	document.addEventListener("DOMContentLoaded", () => {
-		initTextReveal();
-	});
+	window.addEventListener(
+		"load",
+		() => {
+			requestAnimationFrame(() => initTextReveal());
+		},
+		{ once: true }
+	);
 
 	// Astro 頁面切換後重新初始化
 	document.addEventListener("astro:page-load", () => {
-		initTextReveal();
+		requestAnimationFrame(() => initTextReveal());
 	});
 
 	// 視窗大小改變時重新計算


### PR DESCRIPTION
## Summary

- Use `load` event instead of `DOMContentLoaded` for text reveal initialization
- Wrap `initTextReveal()` in `requestAnimationFrame()` for both `load` and `astro:page-load`

## Why

`SplitText` measures element widths to determine line breaks. Previously it ran on `DOMContentLoaded`, which fires before fonts and stylesheets finish loading — causing incorrect line splits based on fallback font metrics.

### `load` event
The `load` event fires after **all** sub-resources (fonts, stylesheets, images) are fully loaded, so `SplitText` measurements reflect the final rendered layout.

### `requestAnimationFrame`
Even after `load`, the browser may not have flushed its latest layout/paint pass. `rAF` defers execution to just before the next paint frame, guaranteeing:
1. All pending style recalculations and reflows are complete
2. Element dimensions read by `SplitText` are final and accurate
3. Any last-moment font rendering adjustments (hinting, subpixel) are settled

## Test plan

- [ ] Verify text reveal animations split lines correctly on first load (especially with custom web fonts)
- [ ] Verify animations work after Astro page transitions
- [ ] Verify resize handling still re-splits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)