### PR TITLE
feat: change session block from div to anchor link

### DIFF
--- a/src/components/agenda/SessionBlock.astro
+++ b/src/components/agenda/SessionBlock.astro
@@ -417,6 +417,13 @@ const sessionHref = hasDescription ? (lang === "en" ? `/2026/en/agenda/${session
 					return;
 				}
 
+				// Only intercept unmodified primary-button clicks so modifier-clicks
+				// (Ctrl/Cmd/Shift/Alt or middle-click) keep default link behavior.
+				const mouseEvent = e as MouseEvent;
+				if (mouseEvent.defaultPrevented || mouseEvent.button !== 0 || mouseEvent.metaKey || mouseEvent.ctrlKey || mouseEvent.shiftKey || mouseEvent.altKey) {
+					return;
+				}
+
 				e.preventDefault();
 
 				const venue = block.getAttribute("data-session-venue") || "";


### PR DESCRIPTION
## Summary

- 將議程區塊從 `<div>` 改為 `<a href>` 元素，讓使用者可以右鍵、中鍵或 Ctrl/Cmd+點擊在新分頁開啟議程
- 一般左鍵點擊仍會 `preventDefault` 並開啟 modal，行為不變
- 有描述的議程才會帶 `href`（例如 `/2026/agenda/{id}/`），無描述的議程不設 href
- 加了 `text-decoration: none; color: inherit;` 維持原本外觀
- 修正內部連結判斷邏輯，確保 block 內的連結仍可正常點擊

https://github.com/user-attachments/assets/16ecbd07-0f13-4bba-9068-df6ae61e0cf0

| Generic | Agenda |
| :-----: | :-----: |
| <img width="934" height="1582" alt="CleanShot 2026-03-08 at 16 18 40@2x" src="https://github.com/user-attachments/assets/23cc8642-6038-42a5-b10a-69e9a412b813" /> | <img width="1206" height="1396" alt="CleanShot 2026-03-08 at 16 18 37@2x" src="https://github.com/user-attachments/assets/b89bb4f9-38b2-4105-a3ec-fd84fc7377e9" /> |

After 5e37f34:

https://github.com/user-attachments/assets/fdbaae7e-9de0-4df0-853b-4246f7e4f87f

## Test plan

- [x] 左鍵點擊議程區塊 → modal 正常開啟，URL 更新
- [x] 右鍵點擊議程區塊 → 出現「在新分頁開啟」選項
- [x] Ctrl/Cmd + 點擊 → 在新分頁開啟對應議程頁面
- [x] 中鍵點擊 → 在新分頁開啟
- [x] 點擊書籤星號 → 不觸發 modal，只切換書籤狀態
- [x] 無描述的議程（generic 等）→ 點擊無反應，不跳頁

🤖 Generated with [Claude Code](https://claude.com/claude-code)